### PR TITLE
Animate rotation of chevron

### DIFF
--- a/Expandable List View/View/ContentViewCell.swift
+++ b/Expandable List View/View/ContentViewCell.swift
@@ -32,7 +32,8 @@ struct ContentViewCell: View {
                     .font(.headline)
                 
                 Spacer()
-                Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                Image(systemName: "chevron.down")
+                    .rotationEffect(.degrees(isExpanded ? -180 : 0))
                     .font(.system(size: 22, weight: .regular))
                     .foregroundColor(.black)
                     .padding(.trailing, 40)


### PR DESCRIPTION
Hi @NilaakashSingh! I'm curious what you'll make of this rotation effect that uses a single chevron image. I'm rotating the chevron -180 degrees when the cell is expanded and then back to its origin. I'm happy to update the README gif as well if you'd like to include this change in the project.

Thanks for making this project!

---




Before | After
--|--
![before](https://user-images.githubusercontent.com/5240843/87995734-2c4ed580-caa5-11ea-8be4-aed32af7e04a.gif) | ![after](https://user-images.githubusercontent.com/5240843/87995653-f578bf80-caa4-11ea-9325-74a21c4181ab.gif)